### PR TITLE
Add Tags API support

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,7 +12,8 @@
 			"Bash(sed:*)",
 			"Bash(git add:*)",
 			"Bash(rg:*)",
-			"Bash(ls:*)"
+			"Bash(ls:*)",
+			"Bash(git checkout:*)"
 		],
 		"deny": []
 	}

--- a/README.md
+++ b/README.md
@@ -43,6 +43,10 @@ const note = await caret.notes.get('note_id');
 if (note) {
   console.log(note);
 }
+
+// List all tags
+const tags = await caret.tags.list();
+console.log(tags);
 ```
 
 ## Authentication
@@ -101,6 +105,21 @@ const updatedNote = await caret.notes.update('note_id', {
 });
 ```
 
+### Tags
+
+The tags resource allows you to manage workspace tags.
+
+```typescript
+// List all tags in the workspace
+const tags = await caret.tags.list();
+
+// Create a new tag
+const newTag = await caret.tags.create({
+  name: 'Important',
+  color: '#FF5733'
+});
+```
+
 ## Rate Limits
 
 The client automatically handles rate limiting based on your Caret plan:
@@ -147,12 +166,17 @@ try {
 This library is written in TypeScript and provides comprehensive type definitions:
 
 ```typescript
-import type { Note, NoteStatus, NoteVisibility } from '@theventures/caret';
+import type { Note, NoteStatus, NoteVisibility, Tag } from '@theventures/caret';
 
 const note: Note | null = await caret.notes.get('note_id');
 if (note) {
   console.log(note.title); // Fully typed
 }
+
+const tags: Tag[] = await caret.tags.list();
+tags.forEach(tag => {
+  console.log(tag.name, tag.color); // Fully typed
+});
 ```
 
 ## Requirements

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,5 +1,6 @@
 import { CaretAPIError } from "./core/errors.js";
 import { Notes } from "./resources/notes.js";
+import { Tags } from "./resources/tags.js";
 import type { APIErrorData, ResponseBody } from "./types/common.js";
 
 export interface CaretOptions {
@@ -16,6 +17,7 @@ export class Caret {
 	readonly maxRetries: number;
 
 	notes: Notes;
+	tags: Tags;
 
 	constructor(options: CaretOptions = {}) {
 		this.apiKey = options.apiKey ?? process.env.CARET_API_KEY ?? "";
@@ -30,6 +32,7 @@ export class Caret {
 		}
 
 		this.notes = new Notes(this);
+		this.tags = new Tags(this);
 	}
 
 	async request(

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,6 +13,7 @@ export {
 	UnprocessableEntityError,
 } from "./core/errors.js";
 export { Notes } from "./resources/notes.js";
+export { Tags } from "./resources/tags.js";
 export type {
 	Note,
 	NoteKind,
@@ -26,3 +27,9 @@ export type {
 	NoteUpdateParams,
 	NoteVisibility,
 } from "./types/note.js";
+export type {
+	Tag,
+	TagCreateParams,
+	TagResponse,
+	TagsListResponse,
+} from "./types/tags.js";

--- a/src/resources/tags.ts
+++ b/src/resources/tags.ts
@@ -1,0 +1,29 @@
+import { APIResource } from "../core/resource.js";
+import type {
+	Tag,
+	TagCreateParams,
+	TagResponse,
+	TagsListResponse,
+} from "../types/tags.js";
+
+export class Tags extends APIResource {
+	/**
+	 * Retrieve a list of all tags in the workspace
+	 */
+	async list(): Promise<Tag[]> {
+		const response = (await this._client.get(
+			"/workspace/tags",
+		)) as unknown as TagsListResponse;
+		return response.tags;
+	}
+
+	/**
+	 * Create a new tag in the workspace
+	 */
+	async create(params: TagCreateParams): Promise<Tag> {
+		const response = (await this._client.post("/workspace/tags", {
+			body: params,
+		})) as unknown as TagResponse;
+		return response.tag;
+	}
+}

--- a/src/types/tags.ts
+++ b/src/types/tags.ts
@@ -1,0 +1,19 @@
+export interface Tag {
+	id: string;
+	name: string;
+	color: string;
+	createdAt: string;
+}
+
+export interface TagsListResponse {
+	tags: Tag[];
+}
+
+export interface TagCreateParams {
+	name: string;
+	color: string;
+}
+
+export interface TagResponse {
+	tag: Tag;
+}

--- a/tests/resources/tags.test.ts
+++ b/tests/resources/tags.test.ts
@@ -1,0 +1,305 @@
+import { afterEach, beforeEach, describe, expect, mock, test } from "bun:test";
+import { Caret } from "../../src/client.js";
+import { BadRequestError } from "../../src/core/errors.js";
+import { Tags } from "../../src/resources/tags.js";
+import type { Tag, TagCreateParams } from "../../src/types/tags.js";
+import {
+	castMockToFetch,
+	createMockErrorResponse,
+	createMockResponse,
+} from "../__helpers__/mocks.js";
+
+const sampleTag: Tag = {
+	id: "01887270-89ab-7da0-c95d-9a9e9ebc9h23",
+	name: "Sales",
+	color: "#FF5733",
+	createdAt: "2023-02-15T10:30:00Z",
+};
+
+const sampleTagsListResponse = {
+	tags: [
+		sampleTag,
+		{
+			id: "01887270-45ab-7da0-c95d-9a9e9ebc2k89",
+			name: "Marketing",
+			color: "#9933FF",
+			createdAt: "2023-08-22T15:30:00Z",
+		},
+		{
+			id: "01887270-67cd-7da0-c95d-9a9e9ebc3m12",
+			name: "Engineering",
+			color: "#00FF00",
+			createdAt: "2023-09-10T09:15:00Z",
+		},
+	],
+};
+
+describe("Tags Resource", () => {
+	let originalFetch: typeof globalThis.fetch;
+	let client: Caret;
+	let tags: Tags;
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch;
+		client = new Caret({ apiKey: "sk-test-key" });
+		tags = client.tags;
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	describe("list()", () => {
+		test("should list all tags in the workspace", async () => {
+			globalThis.fetch = castMockToFetch(
+				mock(async () => createMockResponse({ data: sampleTagsListResponse })),
+			);
+
+			const result = await tags.list();
+
+			expect(result).toEqual(sampleTagsListResponse.tags);
+		});
+
+		test("should handle empty tags list", async () => {
+			const emptyResponse = { tags: [] };
+			globalThis.fetch = castMockToFetch(
+				mock(async () => createMockResponse({ data: emptyResponse })),
+			);
+
+			const result = await tags.list();
+
+			expect(result).toEqual([]);
+		});
+
+		test("should call correct endpoint", async () => {
+			let calledUrl = "";
+			let calledMethod = "";
+			globalThis.fetch = castMockToFetch(
+				mock(async (url: string, options: RequestInit) => {
+					calledUrl = url;
+					calledMethod = options.method || "";
+					return createMockResponse({ data: sampleTagsListResponse });
+				}),
+			);
+
+			await tags.list();
+
+			expect(calledUrl).toBe("https://api.caret.so/v1/workspace/tags");
+			expect(calledMethod).toBe("GET");
+		});
+
+		test("should include authorization header", async () => {
+			let authHeader = "";
+			globalThis.fetch = castMockToFetch(
+				mock(async (_url: string, options: RequestInit) => {
+					authHeader =
+						(options.headers as Record<string, string>)?.Authorization || "";
+					return createMockResponse({ data: sampleTagsListResponse });
+				}),
+			);
+
+			await tags.list();
+
+			expect(authHeader).toBe("Bearer sk-test-key");
+		});
+
+		test("should handle 401 authentication error", async () => {
+			globalThis.fetch = castMockToFetch(
+				mock(async () =>
+					createMockErrorResponse(401, { message: "Invalid API key" }),
+				),
+			);
+
+			await expect(tags.list()).rejects.toThrow("Invalid API key");
+		});
+
+		test("should handle 500 server error", async () => {
+			globalThis.fetch = castMockToFetch(
+				mock(async () =>
+					createMockErrorResponse(500, { message: "Internal server error" }),
+				),
+			);
+
+			await expect(tags.list()).rejects.toThrow("Internal server error");
+		});
+	});
+
+	describe("create()", () => {
+		const createParams: TagCreateParams = {
+			name: "New Tag",
+			color: "#123456",
+		};
+
+		const createdTagResponse = {
+			tag: {
+				id: "01887270-new-tag-id",
+				name: "New Tag",
+				color: "#123456",
+				createdAt: "2024-01-15T10:30:00Z",
+			},
+		};
+
+		test("should create a new tag", async () => {
+			globalThis.fetch = castMockToFetch(
+				mock(async () => createMockResponse({ data: createdTagResponse })),
+			);
+
+			const result = await tags.create(createParams);
+
+			expect(result).toEqual(createdTagResponse.tag);
+		});
+
+		test("should send correct request body", async () => {
+			let requestBody = "";
+			globalThis.fetch = castMockToFetch(
+				mock(async (_url: string, options: RequestInit) => {
+					requestBody = options.body as string;
+					return createMockResponse({ data: createdTagResponse });
+				}),
+			);
+
+			await tags.create(createParams);
+
+			expect(JSON.parse(requestBody)).toEqual(createParams);
+		});
+
+		test("should call correct endpoint with POST method", async () => {
+			let calledUrl = "";
+			let calledMethod = "";
+			globalThis.fetch = castMockToFetch(
+				mock(async (url: string, options: RequestInit) => {
+					calledUrl = url;
+					calledMethod = options.method || "";
+					return createMockResponse({ data: createdTagResponse });
+				}),
+			);
+
+			await tags.create(createParams);
+
+			expect(calledUrl).toBe("https://api.caret.so/v1/workspace/tags");
+			expect(calledMethod).toBe("POST");
+		});
+
+		test("should include correct headers", async () => {
+			let headers: Record<string, string> = {};
+			globalThis.fetch = castMockToFetch(
+				mock(async (_url: string, options: RequestInit) => {
+					headers = options.headers as Record<string, string>;
+					return createMockResponse({ data: createdTagResponse });
+				}),
+			);
+
+			await tags.create(createParams);
+
+			expect(headers.Authorization).toBe("Bearer sk-test-key");
+			expect(headers["Content-Type"]).toBe("application/json");
+		});
+
+		test("should handle validation errors", async () => {
+			globalThis.fetch = castMockToFetch(
+				mock(async () =>
+					createMockErrorResponse(400, {
+						message: "Validation failed",
+						errors: {
+							color: "Invalid color format",
+						},
+					}),
+				),
+			);
+
+			await expect(tags.create(createParams)).rejects.toThrow(BadRequestError);
+		});
+
+		test("should handle duplicate tag name error", async () => {
+			globalThis.fetch = castMockToFetch(
+				mock(async () =>
+					createMockErrorResponse(409, {
+						message: "A tag with this name already exists",
+					}),
+				),
+			);
+
+			await expect(tags.create(createParams)).rejects.toThrow(
+				"A tag with this name already exists",
+			);
+		});
+
+		test("should handle missing required fields", async () => {
+			globalThis.fetch = castMockToFetch(
+				mock(async () =>
+					createMockErrorResponse(422, {
+						message: "Unprocessable Entity",
+						errors: {
+							name: "Name is required",
+							color: "Color is required",
+						},
+					}),
+				),
+			);
+
+			await expect(tags.create({ name: "", color: "" })).rejects.toThrow(
+				"Unprocessable Entity",
+			);
+		});
+
+		test("should create tag with emoji in name", async () => {
+			const emojiParams: TagCreateParams = {
+				name: "🚀 Launch",
+				color: "#FF00FF",
+			};
+
+			const emojiResponse = {
+				tag: {
+					id: "01887270-emoji-tag",
+					name: "🚀 Launch",
+					color: "#FF00FF",
+					createdAt: "2024-01-15T10:30:00Z",
+				},
+			};
+
+			globalThis.fetch = castMockToFetch(
+				mock(async () => createMockResponse({ data: emojiResponse })),
+			);
+
+			const result = await tags.create(emojiParams);
+
+			expect(result).toEqual(emojiResponse.tag);
+		});
+
+		test("should handle rate limit error", async () => {
+			// Use a client with no retries to avoid timeout in tests
+			const noRetryClient = new Caret({ apiKey: "sk-test-key", maxRetries: 0 });
+			const noRetryTags = noRetryClient.tags;
+
+			globalThis.fetch = castMockToFetch(
+				mock(async () =>
+					createMockErrorResponse(
+						429,
+						{ message: "Rate limit exceeded" },
+						{ "Retry-After": "60" },
+					),
+				),
+			);
+
+			await expect(noRetryTags.create(createParams)).rejects.toThrow(
+				"Rate limit exceeded",
+			);
+		});
+	});
+
+	describe("integration with Caret client", () => {
+		test("should access tags through client instance", () => {
+			expect(client.tags).toBeInstanceOf(Tags);
+			expect(client.tags).toBe(tags);
+		});
+
+		test("should share client configuration", () => {
+			const customClient = new Caret({
+				apiKey: "custom-key",
+				baseURL: "https://custom.api.caret.so/v1",
+			});
+
+			expect(customClient.tags).toBeInstanceOf(Tags);
+		});
+	});
+});


### PR DESCRIPTION
## Summary
- Implement Tags resource with `list()` and `create()` methods for managing workspace tags
- Add comprehensive TypeScript types and interfaces for Tag models
- Include full test coverage with 17 test cases achieving 100% coverage

## Implementation Details

### New Files
- `src/types/tags.ts` - TypeScript interfaces for Tag, TagsListResponse, TagCreateParams, and TagResponse
- `src/resources/tags.ts` - Tags resource class implementing list() and create() methods
- `tests/resources/tags.test.ts` - Comprehensive test suite with 17 test cases

### Modified Files
- `src/client.ts` - Added Tags resource integration to main Caret client
- `src/index.ts` - Exported Tags class and related types
- `README.md` - Added documentation and examples for Tags API

## API Methods

### `tags.list()`
Retrieves all tags in the workspace.

### `tags.create(params)`
Creates a new tag with specified name and color.

## Test Coverage
- All API methods tested with success and error scenarios
- Error handling for 400, 401, 409, 422, 429, and 500 status codes
- Integration tests with Caret client
- 100% code coverage achieved

## Test Plan
- [x] Run `bun test` - All 93 tests passing
- [x] Run `bun tsc --noEmit` - TypeScript compilation successful
- [x] Run `bun format` - Code formatting applied

🤖 Generated with [Claude Code](https://claude.ai/code)