### PR TITLE
Add CalendarEvent type to Note interface

### DIFF
--- a/src/types/note.ts
+++ b/src/types/note.ts
@@ -20,6 +20,24 @@ export interface NoteTranscript {
 	endTimestamp: string;
 }
 
+export interface CalendarEventAttendee {
+	self: boolean;
+	email: string;
+	displayName: string;
+}
+
+export interface CalendarEvent {
+	id: string;
+	href: string;
+	title: string;
+	endsAt: string;
+	startsAt: string;
+	attendees: CalendarEventAttendee[];
+	createdAt: string;
+	updatedAt: string;
+	calendarId: string;
+}
+
 export type NoteKind = "online" | "in-person" | "podcast";
 
 export type NoteStatus =
@@ -47,6 +65,7 @@ export interface Note {
 	enhancedNote: string;
 	summary: string;
 	transcripts: NoteTranscript[];
+	calendarEvent?: CalendarEvent;
 }
 
 export interface NotesListParams {

--- a/tests/__helpers__/mocks.ts
+++ b/tests/__helpers__/mocks.ts
@@ -97,6 +97,30 @@ export function mockFetchWithDelay(
 	) as MockFetch;
 }
 
+export const sampleCalendarEvent = {
+	id: "cal_event_123",
+	href: "https://www.google.com/calendar/event?eid=test123",
+	title: "Test Meeting",
+	endsAt: "2024-01-01T11:00:00Z",
+	startsAt: "2024-01-01T10:00:00Z",
+	attendees: [
+		{
+			self: true,
+			email: "john@example.com",
+			displayName: "John Doe",
+		},
+		{
+			self: false,
+			email: "jane@example.com",
+			displayName: "Jane Smith",
+		},
+	],
+	createdAt: "2024-01-01T09:00:00Z",
+	updatedAt: "2024-01-01T09:30:00Z",
+	calendarId:
+		"c_096f13ae8a6ee399087a627c9210a79a04db790c58a2d205d4d05cb37f81748b@group.calendar.google.com",
+};
+
 export const sampleNote = {
 	id: "note_123",
 	title: "Test Meeting Notes",

--- a/tests/resources/notes.test.ts
+++ b/tests/resources/notes.test.ts
@@ -9,6 +9,7 @@ import {
 	castMockToFetch,
 	createMockErrorResponse,
 	createMockResponse,
+	sampleCalendarEvent,
 	sampleNote,
 	sampleNotesListResponse,
 } from "../__helpers__/mocks.js";
@@ -153,6 +154,43 @@ describe("Notes Resource", () => {
 
 			expect(result).toEqual(sampleNote);
 			expect(calledUrl).toBe("https://api.caret.so/v1/notes/note_123");
+		});
+
+		test("should get note with calendarEvent", async () => {
+			const noteWithCalendar = {
+				...sampleNote,
+				calendarEvent: sampleCalendarEvent,
+			};
+			const responseData = { note: noteWithCalendar };
+			let calledUrl = "";
+			globalThis.fetch = castMockToFetch(
+				mock(async (url: string) => {
+					calledUrl = url;
+					return createMockResponse({ data: responseData });
+				}),
+			);
+
+			const result = await notes.get("note_with_calendar");
+
+			expect(result).toEqual(noteWithCalendar);
+			expect(result?.calendarEvent).toEqual(sampleCalendarEvent);
+			expect(result?.calendarEvent?.attendees).toHaveLength(2);
+			expect(calledUrl).toBe(
+				"https://api.caret.so/v1/notes/note_with_calendar",
+			);
+		});
+
+		test("should get note without calendarEvent", async () => {
+			const noteWithoutCalendar = { ...sampleNote, calendarEvent: undefined };
+			const responseData = { note: noteWithoutCalendar };
+			globalThis.fetch = castMockToFetch(
+				mock(async () => createMockResponse({ data: responseData })),
+			);
+
+			const result = await notes.get("note_without_calendar");
+
+			expect(result).toEqual(noteWithoutCalendar);
+			expect(result?.calendarEvent).toBeUndefined();
 		});
 
 		test("should handle special characters in note ID", async () => {


### PR DESCRIPTION
## Summary
- Add optional `calendarEvent` field to the Note interface to support calendar integration data returned by the Caret API
- While not documented in the official API docs, the actual API responses include this field with meeting details from integrated calendars
- Add comprehensive test coverage for notes with and without calendar events

## Changes
- Define `CalendarEvent` and `CalendarEventAttendee` interfaces based on actual API response structure
- Add optional `calendarEvent?: CalendarEvent` field to the `Note` type
- Add test cases to verify proper handling of notes with and without calendar events
- Include sample calendar event data in test mocks

## Test plan
✅ All existing tests pass
✅ Added new tests for calendar event scenarios
✅ TypeScript compilation successful
✅ Code formatting and linting complete

🤖 Generated with [Claude Code](https://claude.ai/code)