### PR TITLE
[v3] Migrate webhook types to Meeting

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -15,7 +15,10 @@
 			"Bash(git checkout:*)",
 			"Bash(node:*)",
 			"Bash(cat:*)",
-			"Bash(gh api:*)"
+			"Bash(gh api:*)",
+			"WebFetch(domain:caret.so)",
+			"Bash(grep:*)",
+			"Bash(python3:*)"
 		],
 		"deny": []
 	}

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@
 [![MIT License](https://img.shields.io/badge/license-MIT-blue.svg)](https://github.com/theventures/caret/blob/main/LICENSE)
 
 
-[Caret](https://caret.so) is an AI meeting notetaker that transcribes and translates in real-time. This library provides a convenient way to interact with the [Caret API](https://docs.caret.so/api-reference/overview) from Node.js applications.
+[Caret](https://caret.so) is an AI meeting notetaker that transcribes and translates in real-time. This library provides a convenient way to interact with the [Caret API](https://docs.caret.so/api-reference/introduction) from Node.js applications.
+
+> **Note:** The Caret API is undergoing significant changes. Authentication is migrating from Bearer tokens to `X-API-Key` headers, Tags/Groups are being replaced by Folders, and new resources (Folders, Audio Upload) are being added. See the [latest API documentation](https://docs.caret.so/api-reference/introduction) for details. This library will be updated to support the new API in an upcoming release.
 
 ## Installation
 
@@ -333,13 +335,13 @@ For issues with this library:
 ## Links
 
 - [Caret Official Website](https://caret.so)
-- [Caret API Documentation](https://docs.caret.so/api-reference/overview)
+- [Caret API Documentation](https://docs.caret.so/api-reference/introduction)
 - [npm Package](https://www.npmjs.com/package/@theventures/caret)
 - [GitHub Repository](https://github.com/theventures/caret)
 
 ## About
 
-This package is published by [TheVentures](https://theventures.vc), the investment company behind [At Inc.](https://www.at.studio) (the company that operates Caret).
+This package is published by [TheVentures](https://theventures.vc), the investment company behind [At Your Side Inc.](https://www.at.studio) (the company that operates Caret).
 
 ### Built with AI
 

--- a/README.md
+++ b/README.md
@@ -236,22 +236,23 @@ import { WebhookVerifier } from '@theventures/caret';
 // Next.js App Router example
 export async function POST(request: Request) {
   // Uses CARET_WEBHOOK_SECRET env var automatically or you can pass it in the constructor
-  const verifier = new WebhookVerifier(); 
-  
+  const verifier = new WebhookVerifier();
+
   // Verify and parse in one step with full type safety
-  const { isValid, data, error } = await verifier.verifyRequest<'note.created'>(request);
-  
+  const { isValid, data, error } = await verifier.verifyRequest<'meeting.created'>(request);
+
   if (!isValid) {
     console.error('Webhook verification failed:', error);
     return new Response('Unauthorized', { status: 401 });
   }
-  
-  // data is fully typed as WebhookEventMap['note.created']
-  const note = data.payload.note; // Fully typed as Note
-  console.log('New note created:', note.title);
-  console.log('Participants:', note.participants);
-  // Process the note...
-  
+
+  // data is fully typed as WebhookEventMap['meeting.created']
+  const meeting = data.payload.meeting; // Fully typed as Meeting
+  console.log('New meeting created:', meeting.title);
+  console.log('Summary:', meeting.summary.content);
+  console.log('Transcripts:', meeting.transcripts.length);
+  // Process the meeting...
+
   return new Response('OK', { status: 200 });
 }
 ```
@@ -261,15 +262,16 @@ export async function POST(request: Request) {
 This library is written in TypeScript and provides comprehensive type definitions:
 
 ```typescript
-import type { 
-  Note, 
-  NoteStatus, 
-  NoteVisibility, 
+import type {
+  Note,
+  NoteStatus,
+  NoteVisibility,
   Tag,
   WorkspaceType,
   Member,
   Group,
   Invite,
+  Meeting,
   WebhookEvent,
   WebhookEventMap
 } from '@theventures/caret';
@@ -302,14 +304,14 @@ const invite: Invite = await caret.workspace.createInvite({
 console.log(invite.code, invite.expiresAt, invite.groups); // Fully typed
 
 // Webhook event types
-const webhookEvent: WebhookEventMap['note.created'] = {
-  type: 'note.created',
+const webhookEvent: WebhookEventMap['meeting.created'] = {
+  type: 'meeting.created',
   eventId: 'evt_123',
   webhookId: 'wh_456',
   workspaceId: 'ws_789',
   timestamp: '2024-01-01T00:00:00Z',
   payload: {
-    note: note! // Fully typed as Note
+    meeting: { /* Fully typed as Meeting */ } as Meeting
   }
 };
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,17 @@ export { Notes } from "./resources/notes.js";
 export { Tags } from "./resources/tags.js";
 export { Workspace } from "./resources/workspace.js";
 export type {
+	Meeting,
+	MeetingAclRule,
+	MeetingCalendarEvent,
+	MeetingCalendarEventAttendee,
+	MeetingCreator,
+	MeetingSpeakerAnalysis,
+	MeetingSummary,
+	MeetingTranscript,
+	MeetingTranscriptWord,
+} from "./types/meeting.js";
+export type {
 	Note,
 	NoteKind,
 	NoteParticipant,
@@ -35,8 +46,8 @@ export type {
 	TagsListResponse,
 } from "./types/tags.js";
 export type {
-	NoteAudioUploadedPayload,
-	NoteCreatedPayload,
+	MeetingAudioUploadedPayload,
+	MeetingCreatedPayload,
 	TestPayload,
 	WebhookEvent,
 	WebhookEventMap,

--- a/src/types/meeting.ts
+++ b/src/types/meeting.ts
@@ -1,0 +1,104 @@
+export interface MeetingTranscriptWord {
+	end: number;
+	text: string;
+	start: number;
+}
+
+export interface MeetingTranscript {
+	id: string;
+	end: number;
+	text: string;
+	start: number;
+	words: MeetingTranscriptWord[];
+	speaker: string;
+	chunkId: string;
+	segmentId: string;
+}
+
+export interface MeetingSpeakerAnalysis {
+	id: string;
+	name: string;
+	role: string;
+	nameReason: string;
+	voiceSampleUrl: string;
+	voiceCharacteristics: string;
+}
+
+export interface MeetingSummary {
+	content: string;
+	language: string;
+	created_at: string;
+	template_id: string | null;
+}
+
+export interface MeetingCreator {
+	id: string;
+	name: string;
+	email: string;
+	locale: string;
+	job_title: string;
+	profile_url: string;
+}
+
+export interface MeetingAclRule {
+	id: string;
+	user: string | null;
+	folder: string | null;
+	can_read: boolean;
+	can_write: boolean;
+	principal_type: string;
+}
+
+export interface MeetingCalendarEventAttendee {
+	self: boolean;
+	email: string;
+	displayName: string;
+}
+
+export interface MeetingCalendarEvent {
+	id: string;
+	href: string;
+	title: string;
+	endsAt: string;
+	startsAt: string;
+	timezone: string;
+	createdAt: string;
+	updatedAt: string;
+	calendarId: string;
+	uuid: string;
+	attendees: MeetingCalendarEventAttendee[];
+}
+
+export interface Meeting {
+	id: string;
+	workspace_id: string;
+	status: string;
+	permission: string;
+	title: string;
+	private_note: string;
+	total_duration_sec: number;
+	meeting_autostarted_app: string | null;
+	audio_location: string;
+	audio_url: string;
+	created_by: string;
+	created_at: string;
+	updated_at: string;
+	archived_at: string | null;
+	suggestions: Record<string, unknown>;
+	calendar_event_id: string;
+	transcripts: MeetingTranscript[];
+	language: string;
+	is_auto_ended: boolean;
+	auto_end_reason: string | null;
+	live_scenario_id: string;
+	questions: Record<string, unknown>;
+	speaker_analysis: MeetingSpeakerAnalysis[];
+	linked_crm: string | null;
+	reference_call_supermemory_id: string | null;
+	llm_sharing_agreed_at: string | null;
+	summary: MeetingSummary;
+	calendarEvent: MeetingCalendarEvent;
+	timelineSummary: string;
+	creator: MeetingCreator;
+	acl_rules: MeetingAclRule[];
+}

--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -1,4 +1,4 @@
-import type { Note } from "./note.js";
+import type { Meeting } from "./meeting.js";
 
 export interface WebhookEvent<T = unknown> {
 	type: string;
@@ -9,13 +9,12 @@ export interface WebhookEvent<T = unknown> {
 	payload: T;
 }
 
-export interface NoteCreatedPayload {
-	note: Note;
+export interface MeetingCreatedPayload {
+	meeting: Meeting;
 }
 
-export interface NoteAudioUploadedPayload {
-	noteId: string;
-	audioUrl: string;
+export interface MeetingAudioUploadedPayload {
+	audio_url: string;
 }
 
 export interface TestPayload {
@@ -23,8 +22,8 @@ export interface TestPayload {
 }
 
 export type WebhookEventMap = {
-	"note.created": WebhookEvent<NoteCreatedPayload>;
-	"note.audio_uploaded": WebhookEvent<NoteAudioUploadedPayload>;
+	"meeting.created": WebhookEvent<MeetingCreatedPayload>;
+	"meeting.audio_uploaded": WebhookEvent<MeetingAudioUploadedPayload>;
 	test: WebhookEvent<TestPayload>;
 };
 


### PR DESCRIPTION
## Summary

Migrate webhook event types from `note.*` to `meeting.*` to align with the updated Caret API. This introduces the `Meeting` type with a comprehensive schema and updates all webhook payloads, exports, documentation, and tests accordingly.

## Changes

- `8b8308e` — Update docs (CLAUDE.md, README.md) to reflect new API structure: X-API-Key auth, Folders replacing Tags, new resources
- `ab85af0` — Migrate webhook types from Note to Meeting: add `Meeting` type, rename events (`meeting.created`, `meeting.audio_uploaded`), update tests with realistic meeting payload data

## Details

- **New type**: `Meeting` with full schema — transcripts, summary, calendar event, speaker analysis, ACL rules, creator
- **Renamed payloads**: `NoteCreatedPayload` → `MeetingCreatedPayload`, `NoteAudioUploadedPayload` → `MeetingAudioUploadedPayload`
- **Renamed events**: `note.created` → `meeting.created`, `note.audio_uploaded` → `meeting.audio_uploaded`
- **Updated exports** in `src/index.ts` for all new Meeting-related types
- **Updated tests** with comprehensive meeting data matching actual API responses
- **Updated README** webhook examples to use new Meeting types

🤖 Generated with [Claude Code](https://claude.com/claude-code)